### PR TITLE
cleanups and notions

### DIFF
--- a/Templates/BaseGame/game/core/postFX/scripts/HDR/HDR_toneMap.hlsl
+++ b/Templates/BaseGame/game/core/postFX/scripts/HDR/HDR_toneMap.hlsl
@@ -59,7 +59,7 @@ float3 ACESFitted(float3 x, float w, float gamma)
 	 // clamp
 	 x = saturate(x);
 	 // this should be gamma value
-	 x = pow(x, float3(gamma, gamma, gamma));
+	 //x = pow(x, float3(gamma, gamma, gamma));
      
     return x;
      

--- a/Templates/BaseGame/game/core/rendering/shaders/lighting.hlsl
+++ b/Templates/BaseGame/game/core/rendering/shaders/lighting.hlsl
@@ -387,8 +387,8 @@ void dampen(inout Surface surface, TORQUE_SAMPLER2D(WetnessTexture), float accum
    wetness = lerp(wetness,TORQUE_TEX2D(WetnessTexture,float2(surface.P.zy*0.2+wetoffset)).b,n.x);
    wetness = pow(wetness,3)*degree;
    
-   surface.roughness = lerp(surface.roughness,(1.0-pow(wetness,2))*surface.roughness*0.92f+0.04f,degree);
-   surface.baseColor.rgb = lerp(surface.baseColor.rgb,surface.baseColor.rgb*(2.0-wetness)/2,degree);
+   surface.roughness = clamp(lerp(surface.roughness,(1.0-pow(wetness,2))*surface.roughness,degree),0.04f,0.92f);
+   surface.baseColor.rgb = lerp(surface.baseColor.rgb,surface.baseColor.rgb*(2.0-wetness),degree);
    surface.Update(); 
 }
 

--- a/Templates/BaseGame/game/core/rendering/shaders/lighting/advanced/SSGI/ssgiRayMarch.hlsl
+++ b/Templates/BaseGame/game/core/rendering/shaders/lighting/advanced/SSGI/ssgiRayMarch.hlsl
@@ -13,43 +13,62 @@ uniform float4 rtParams0;
 uniform float4 vsFarPlane;
 uniform float4x4 cameraToWorld;
 uniform float4x4 invCameraMat;
+uniform float2 oneOverTargetSize;
+
+float screenEdgeFade(float2 screenPos)
+{
+  return 1.0-length(screenPos.xy); // eventually we'll wanna do a box fade
+}
 
 float4 RayMarch(float3 dir, float3 screenPos, float stepSize, int stepCount)
 {
 	float mask = 0.0; 
 	float3 samplePos = float3(screenPos.xy * 0.5 + 0.5, screenPos.z);
-	float Depth;
+	float Depth = samplePos.z;
     float DepthDiff = 0;
-	
+	float curStep = stepSize;
 	float prevDepth = samplePos.z;
 	float prevDepthDiff = 0.0;
 	float3 prevSamplePos = samplePos;
+    float3 curDir = dir;
+    float3 curColor = float3(0,0,0);
+    float hitCount = 0;
+    [unroll]
 	for(int i = 0; i < stepCount; i++)
 	{
 		Depth = TORQUE_DEFERRED_UNCONDITION( deferredBuffer, samplePos.xy).w;
-		DepthDiff = samplePos.z - Depth;
-		if(0.0 > DepthDiff)
-		{
-				float blend = (prevDepthDiff - DepthDiff) / max(prevDepth, Depth) * 0.5 + 0.5;
-				samplePos = lerp(prevSamplePos, samplePos, blend);
-				mask = blend;
-				break;
-		}
-		else
-		{
-			prevDepthDiff = -Depth;
-			prevSamplePos = samplePos;
-		}
+		DepthDiff = Depth-prevDepth;
+		if (samplePos.z <= 0.0001 || screenEdgeFade(screenPos.xy)<=0.0)
+        {
+            break;
+        }
+        else
+        {
+            if (DepthDiff>0.0) //we only care if we're going further into th screen
+            {
+                mask += 1.0-(DepthDiff*samplePos.z); 
+                curColor += TORQUE_TEX2D(colorBuffer, samplePos.xy).rgb;
+                curStep *= samplePos.z;
+                hitCount++;
+            }
+            else
+            {
+                //bounce
+                curDir = reflect(-curDir,TORQUE_DEFERRED_UNCONDITION( deferredBuffer, samplePos.xy).xyz);
+            }
+        }
 		prevDepth = Depth;
-		samplePos += dir * stepSize;
+		samplePos += curDir * curStep;
 	}
-	
-	return float4(samplePos, mask);
+    hitCount = max(hitCount,1.0);
+	curColor /= hitCount;
+    mask/=hitCount;
+	return float4(curColor, mask)*screenEdgeFade(screenPos.xy);
 }
 
 float3 getView(float3 screenPos)
 {
-	float4 viewPos = mul(cameraToWorld, float4(screenPos, 0));
+	float4 viewPos = mul(cameraToWorld, float4(screenPos, 1));
 	return viewPos.xyz / viewPos.w;
 }
 
@@ -69,19 +88,12 @@ float4 main(PFXVertToPix IN) : SV_TARGET
    
    // SSGI raymarch - need this to feed into the uv coord for cubemaps
    float3 screenPos = float3(IN.uv0.xy * 2 - 1, normDepth.a);
-   
-   float3 viewPos = getView(screenPos);
-   
-   float jit = random(IN.uv0.xy);
-   float stepSize = (1.0 / 64.0);
-   stepSize = stepSize * jit + stepSize;
-   float3 dir = normalize(mul(float4(viewDir,0), cameraToWorld)).xyz;
-   float rayMask = 0.0;
-   float4 rayTrace = RayMarch(dir, screenPos, stepSize, 16); 
-   float3 hitUV = rayTrace.xyz;
-   rayMask = rayTrace.w; 
-   rayMask = dot(viewDir,mul( float4(surface.N, 0),invCameraMat).xyz);
+      
+   float stepSize = 512.0*length(oneOverTargetSize);
+   float jit = stepSize*(random(IN.uv0.xy)*2-1);
+   stepSize = stepSize * jit;
+   float3 dir = normalize(mul(float4(reflect(IN.wsEyeRay, viewDir),1), cameraToWorld)).xyz;
 
-	float3 sampleColor = TORQUE_TEX2D(colorBuffer, hitUV.xy).rgb * 5.0;
-	return float4(sampleColor,rayMask);
+   float4 rayTrace = RayMarch(dir, screenPos, stepSize, 16);
+   return float4(rayTrace.rgb,rayTrace.a);
 }

--- a/Templates/BaseGame/game/core/rendering/shaders/lighting/advanced/reflectionProbeArrayP.hlsl
+++ b/Templates/BaseGame/game/core/rendering/shaders/lighting/advanced/reflectionProbeArrayP.hlsl
@@ -205,21 +205,21 @@ float4 main(PFXVertToPix IN) : SV_TARGET
    float3 kD = 1.0f - F;
    kD *= 1.0f - surface.metalness;
    float2 envBRDF = TORQUE_TEX2DLOD(BRDFTexture, float4(surface.roughness,surface.NdotV, 0,0)).rg;
+   irradiance = lerp(irradiance, indirect.rgb,indirect.a);
    irradiance *= kD * surface.baseColor.rgb;
-
-   indirect.rgb *= surface.albedo;
 
    float horizon = saturate(1.0 + 1.3 * dot(surface.R, surface.N));
    horizon *= horizon;
    float specularOcc = computeSpecOcclusion(surface.NdotV, surface.ao, surface.roughness);
+   specular = lerp(specular, indirect.rgb,indirect.a);
    specular = specular * min(specularOcc, horizon);
    specular *= F * envBRDF.x + surface.f90 * envBRDF.y;  
   
 #if CAPTURING == 1 
     return float4(lerp(irradiance + specular, surface.baseColor.rgb,surface.metalness),0);
 #else  
-    float4 sampleCol = float4(irradiance + specular, 0) + indirect; //alpha writes disabled
+    float4 sampleCol = float4(irradiance + specular, 0) ; //alpha writes disabled
     sampleCol.rgb *= ambientColor;
 #endif
-	return sampleCol;
+	return sampleCol; 
 }


### PR DESCRIPTION
ditch the *5 multiplier on the screen colorsample.
kill off the rayMask override that was mangling our hit/miss reports 
retool the RayMarch method so that if it bounced back behind the screen, or approaches the edge it gets tossed out, otherwise it bounces around untill it runs out of steam based on struck normal, accumulating color as i goes 
combine indirect GI the same way we do other ibl so the math is used consistently 
clamp the wetness results the same way we do the rest, 
preps edge falloff for gi with a screenEdgedFade method (just a circular falloff atm)